### PR TITLE
Support WAKE flag in keyboard layouts

### DIFF
--- a/include/input/InputEventLabels.h
+++ b/include/input/InputEventLabels.h
@@ -374,6 +374,7 @@ static const InputEventLabel LEDS[] = {
 };
 
 static const InputEventLabel FLAGS[] = {
+    DEFINE_FLAG(WAKE),
     DEFINE_FLAG(VIRTUAL),
     DEFINE_FLAG(FUNCTION),
 


### PR DESCRIPTION
This flag is used to specify the internal keyboard keys allowed
to wake the device.

Change-Id: Ic15aca1134206c9b006a4d97dded10bccae640d3
